### PR TITLE
Añade script de seed y configura proxy de Vite para frontend

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,39 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path' // Importar path para resolver alias si se usa @
 
-// https://vite.dev/config/
+// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: { // Configuración de alias (ej. para @/components)
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 5173, // Puerto por defecto de Vite, se puede cambiar si es necesario
+    proxy: {
+      // Proxy /api/v1 a tu backend en http://192.168.101.11:3770
+      '/api/v1': {
+        target: 'http://192.168.101.11:3770',
+        changeOrigin: true, // Necesario para hosts virtuales o si el backend está en otra IP/dominio
+        secure: false,      // Poner a true si el backend usa HTTPS (incluso con cert autofirmado si se configura bien el agente)
+        // Opcional: reescribir la ruta si es necesario (no en este caso ya que la base /api/v1 es la misma)
+        // rewrite: (path) => path.replace(/^\/api\/v1/, '/api/v1'),
+
+        // Opcional: Loguear las solicitudes proxied para depuración
+        configure: (proxy, _options) => {
+          proxy.on('error', (err, _req, _res) => {
+            console.log('Error de proxy:', err);
+          });
+          proxy.on('proxyReq', (proxyReq, req, _res) => {
+            console.log('Enviando solicitud a Target:', req.method, req.url, '->', proxyReq.protocol + '//' + proxyReq.host + proxyReq.path);
+          });
+          proxy.on('proxyRes', (proxyRes, req, _res) => {
+            console.log('Respuesta recibida del Target:', proxyRes.statusCode, req.url);
+          });
+        }
+      }
+    }
+  }
 })


### PR DESCRIPTION
Este commit incluye dos mejoras principales:

1.  **Script de Datos de Prueba (`database/seed_test_data.sql`):**
    *   He creado un script SQL para poblar la base de datos con un conjunto completo de datos de prueba.
    *   Esto incluye un usuario 'admin' de prueba, configuraciones globales, placeholders para claves API encriptadas (Binance, OpenAI, OpenRouter), pares de trading de ejemplo con `strategy_config` JSON, transacciones simuladas, decisiones de IA y logs del sistema.
    *   El script limpia las tablas relevantes y resetea las secuencias de ID antes de insertar los nuevos datos, permitiendo una ejecución repetible para obtener un estado de prueba consistente.

2.  **Configuración de Proxy en Vite (`frontend/vite.config.js`):**
    *   He configurado el servidor de desarrollo de Vite para el frontend.
    *   Añadí una regla de proxy para redirigir todas las solicitudes hechas desde el frontend a la ruta `/api/v1/...` hacia el servidor backend en `http://192.168.101.11:3770/api/v1/...`. Esto facilita el desarrollo local al permitir que el frontend y el backend se ejecuten en puertos diferentes mientras las llamadas API funcionan como si estuvieran en el mismo origen.
    *   Incluí logging detallado para las solicitudes proxied para ayudar en la depuración.
    *   Añadí un alias de ruta `@` que apunta a `frontend/src/` para importaciones más limpias en el código del frontend.

Estos cambios mejoran significativamente tu experiencia de desarrollo y pruebas del sistema full-stack.