### PR TITLE
Fix(Backend): Corrige paso de parámetros en getKlines de BinanceService

### DIFF
--- a/src/services/BinanceService.js
+++ b/src/services/BinanceService.js
@@ -113,7 +113,7 @@ async function initializeBinanceClient() {
 async function getKlines(symbol, interval = '1h', limit = 100) {
   if (!isInitialized && !binanceClient) throw new Error('Binance client no inicializado.');
   try {
-    const ticks = await binanceClient.candlesticks(symbol, interval, false, { limit });
+    const ticks = await binanceClient.candlesticks(symbol, interval, { limit: limit });
     return ticks.map(t => ({
         openTime: t[0], open: parseFloat(t[1]), high: parseFloat(t[2]), low: parseFloat(t[3]), close: parseFloat(t[4]),
         volume: parseFloat(t[5]), closeTime: t[6], quoteAssetVolume: parseFloat(t[7]), numberOfTrades: t[8],


### PR DESCRIPTION
Este commit soluciona un TypeError en la función getKlines de BinanceService.js. El error ("Cannot create property 'limit' on boolean 'false'") ocurría porque los parámetros para la función 'candlesticks' de la librería node-binance-api no se estaban pasando en el orden correcto cuando se usa con async/await.

La llamada ha sido modificada de:
  `await binanceClient.candlesticks(symbol, interval, false, { limit });`
a:
  `await binanceClient.candlesticks(symbol, interval, { limit: limit });`

Esto asegura que el objeto de opciones, que contiene el parámetro 'limit', se pase como el tercer argumento, como espera la librería cuando no se provee un callback.